### PR TITLE
Refactor a bit to support `id` & `data` on mark

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A annotation "injector" built on the Hypothes.is API.
 ## Usage
 
 ```
+$ npm install -g browserify
 $ npm install
 $ npm run build
 $ python -m SimpleHTTPServer

--- a/dist/trudeau.js
+++ b/dist/trudeau.js
@@ -2824,7 +2824,7 @@ function wrapRangeText(wrapperEl, range) {
 module.exports = wrapRangeText
 
 },{}],7:[function(require,module,exports){
-function attach_annotation(bounds, exact, prefix, data) {
+function attach_annotation(bounds, exact, prefix, payload, data) {
   var wrap = require('wrap-range-text');
   var TextQuoteAnchor = require ('dom-anchor-text-quote');
 
@@ -2832,7 +2832,9 @@ function attach_annotation(bounds, exact, prefix, data) {
   var range = tqa.toRange();
 
   var highlight = document.createElement('mark');
-  highlight.title = data;
+  highlight.id = 'hypothesis-' + data.id;
+  highlight.setAttribute('data-hypothesis', JSON.stringify(data));
+  highlight.title = payload;
   highlight.className = bounds + ' hypothesis_annotation';
 
   wrap(highlight, range);
@@ -2848,6 +2850,7 @@ function get_annotations(uri) {
   });
   xhr.open("GET", url);
   xhr.send();
+  return xhr;
 }
 
 function get_selector_with(selector_list, key) {
@@ -2888,7 +2891,9 @@ function attach_annotations(data) {
     var position = text_position_selector['start'] + '_' + text_position_selector['end']
     if ( anno_dict.hasOwnProperty(position) == false ) {
       anno_dict[position] = [];
-      anno_dict[position].push( { "user":user, "position":position, "exact":exact, "text":text, "prefix":prefix } );
+      anno_dict[position].push( {
+        "id":row['id'], "user":user, "position":position, "exact":exact,
+        "text":text, "prefix":prefix } );
     }
   }
 
@@ -2907,7 +2912,7 @@ function attach_annotations(data) {
       payload += anno['user'] + '\n' + anno['text'] + '\n\n';
     }
 
-    attach_annotation( key, exact, prefix, payload );
+    attach_annotation( key, exact, prefix, payload, anno );
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -151,7 +151,11 @@ mark { background-color: rgba(0,20,220,0.2); }
 
 <script src="./dist/trudeau.js"></script>
 <script>
-  get_annotations('http://jonudell.net/h/trudeau.html');
+  var xhr = get_annotations('http://jonudell.net/h/trudeau.html');
+  xhr.addEventListener("load", function() {
+    console.log('page knows ajax is done, and so are the annotations...');
+    console.log('See:', document.querySelectorAll('mark'));
+  });
 </script>
 </body>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-function attach_annotation(bounds, exact, prefix, data) {
+function attach_annotation(bounds, exact, prefix, payload, data) {
   var wrap = require('wrap-range-text');
   var TextQuoteAnchor = require ('dom-anchor-text-quote');
 
@@ -6,7 +6,9 @@ function attach_annotation(bounds, exact, prefix, data) {
   var range = tqa.toRange();
 
   var highlight = document.createElement('mark');
-  highlight.title = data;
+  highlight.id = 'hypothesis-' + data.id;
+  highlight.setAttribute('data-hypothesis', JSON.stringify(data));
+  highlight.title = payload;
   highlight.className = bounds + ' hypothesis_annotation';
 
   wrap(highlight, range);
@@ -22,6 +24,7 @@ function get_annotations(uri) {
   });
   xhr.open("GET", url);
   xhr.send();
+  return xhr;
 }
 
 function get_selector_with(selector_list, key) {
@@ -62,7 +65,9 @@ function attach_annotations(data) {
     var position = text_position_selector['start'] + '_' + text_position_selector['end']
     if ( anno_dict.hasOwnProperty(position) == false ) {
       anno_dict[position] = [];
-      anno_dict[position].push( { "user":user, "position":position, "exact":exact, "text":text, "prefix":prefix } );
+      anno_dict[position].push( {
+        "id":row['id'], "user":user, "position":position, "exact":exact,
+        "text":text, "prefix":prefix } );
     }
   }
 
@@ -81,7 +86,7 @@ function attach_annotations(data) {
       payload += anno['user'] + '\n' + anno['text'] + '\n\n';
     }
 
-    attach_annotation( key, exact, prefix, payload );
+    attach_annotation( key, exact, prefix, payload, anno );
   }
 }
 


### PR DESCRIPTION
Also return xhr on get_annotations for watching elsewhere.
See index.html for a silly example.
